### PR TITLE
fixes #48

### DIFF
--- a/simpleMenuWizard/tab-context.css
+++ b/simpleMenuWizard/tab-context.css
@@ -27,6 +27,7 @@
 /* #tabContextMenu #context_moveToEnd,                            /* Move to End             */
 /* #tabContextMenu #context_openTabInWindow,                      /* Move to New Window      */
 /* #tabContextMenu #context_sendTabToDevice,                  /* Send Tab to Device      */
+/* #tabContextMenu #context_shareTabURL */                    /* Share tab URL via 3rd party app */
 /* #tabContextMenu #context_reopenInContainer,                /* Reopen in Container     */
 /* #tabContextMenu #context_dummy,                                /* Send Tab to Device Submenu not yet supported */
 /* #tabContextMenu #context_selectAllTabs,                    /* Select All Tabs         */


### PR DESCRIPTION
Adds documentation of the #tabContextMenu selector for the "Share" menuitem that appeared in FF89 (source: [https://searchfox.org/mozilla-release/source/browser/base/content/tabbrowser.js#7180](https://searchfox.org/mozilla-release/source/browser/base/content/tabbrowser.js#7180))